### PR TITLE
override system error in build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ USER root
 ENV PYTHONUNBUFFERED=1
 RUN apt-get update 
 RUN apt-get -y install python3 python3-pip && ln -sf python3 /usr/bin/python
-RUN pip3 install --no-cache --upgrade pip setuptools
-RUN pip3 install -r /tmp/requirements.txt
+RUN pip3 install --no-cache --upgrade --break-system-packages pip setuptools
+RUN pip3 install --break-system-packages -r /tmp/requirements.txt
 COPY ./scripts/*.py /usr/local/bin/
 COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
Use "--break-system-packages" to tell pip to override package error. 